### PR TITLE
docs: add CONTRIBUTING.md with full contributor workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to ZeroDAST
+
+Welcome! We are glad you want to contribute. This guide covers the full contribution workflow.
+
+## Prerequisites
+
+- **Node.js 22+** (for `demo-app` lint/tests)
+- **Python 3.11+** (for overlay validation)
+- **Docker or Podman** (for running the demo application)
+
+## Getting Started
+
+1. Fork the repository and clone your fork.
+2. Create a branch with a descriptive name:
+   ```bash
+   git checkout -b fix/your-fix-description
+   ```
+3. Make your changes, keeping them focused and small.
+4. Open a pull request against `main`.
+
+## Running demo-app lint and tests
+
+```bash
+cd demo-app
+npm ci
+npm run lint
+npm test
+```
+
+## Validating an overlay
+
+```bash
+python db/seed/validate_overlay.py <path-to-overlay.sql>
+```
+
+## Security-sensitive contributions
+
+If your change touches `overlay.sql` or database seeding logic, read [docs/CONTRIBUTING_SECURITY.md](docs/CONTRIBUTING_SECURITY.md) before submitting.
+
+## PR checklist
+
+- [ ] Changes are focused and minimal
+- [ ] Code matches the existing style
+- [ ] Tests pass (`npm test` in `demo-app`)
+- [ ] Overlay validated if modified
+
+## Good first issues
+
+Looking for somewhere to start? Check issues labeled [`good first issue`](https://github.com/AlphaSudo/zerodast/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+
+## Questions?
+
+Open an issue or start a discussion — we are happy to help.

--- a/README.md
+++ b/README.md
@@ -432,7 +432,9 @@ To report a security issue in ZeroDAST itself, see [SECURITY.md](SECURITY.md).
 
 ## 🤝 Contributing
 
-See [CONTRIBUTING_SECURITY.md](docs/CONTRIBUTING_SECURITY.md) for security-sensitive contribution guidelines.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution guide (prerequisites, running tests, overlay validation, and PR checklist).
+
+For security-sensitive changes, also read [CONTRIBUTING_SECURITY.md](docs/CONTRIBUTING_SECURITY.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `CONTRIBUTING.md` at the repo root and updates the README Contributing section to link to it, as specified in #80.

**CONTRIBUTING.md includes:**
- Prerequisites (Node 22, Python 3.11+, Docker/Podman)
- How to run `demo-app` lint/tests (`cd demo-app && npm ci && npm run lint && npm test`)
- How to validate an overlay (`python db/seed/validate_overlay.py ...`)
- Link to `docs/CONTRIBUTING_SECURITY.md` for security-sensitive changes
- PR checklist (focused changes, existing style, tests pass)
- Link to `good first issue` label for new contributors

**README update:**
- Contributing section now points to `CONTRIBUTING.md` as the primary entry point, with `CONTRIBUTING_SECURITY.md` as the security-specific supplement.

Closes #80