### PR TITLE
docs: improve README badge and image alt text for accessibility (#83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
     <strong>Enterprise-grade CI DAST for open-source repositories. Zero cost. Zero vendor lock-in.</strong>
   </p>
   <p align="center">
-    <a href="https://github.com/AlphaSudo/zerodast/actions"><img src="https://img.shields.io/github/actions/workflow/status/AlphaSudo/zerodast/dast-nightly.yml?branch=main&label=Nightly%20DAST&style=flat-square" alt="Nightly DAST"></a>
-    <a href="https://github.com/AlphaSudo/zerodast/actions"><img src="https://img.shields.io/github/actions/workflow/status/AlphaSudo/zerodast/ci.yml?branch=main&label=CI&style=flat-square" alt="CI"></a>
-    <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License"></a>
-    <img src="https://img.shields.io/badge/release-alpha-orange?style=flat-square" alt="Alpha">
-    <img src="https://img.shields.io/badge/cost-%240-brightgreen?style=flat-square" alt="Cost: $0">
+    <a href="https://github.com/AlphaSudo/zerodast/actions"><img src="https://img.shields.io/github/actions/workflow/status/AlphaSudo/zerodast/dast-nightly.yml?branch=main&label=Nightly%20DAST&style=flat-square" alt="Nightly DAST workflow status"></a>
+    <a href="https://github.com/AlphaSudo/zerodast/actions"><img src="https://img.shields.io/github/actions/workflow/status/AlphaSudo/zerodast/ci.yml?branch=main&label=CI&style=flat-square" alt="CI build status for main branch"></a>
+    <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License: Apache 2.0"></a>
+    <img src="https://img.shields.io/badge/release-alpha-orange?style=flat-square" alt="Release status: Alpha">
+    <img src="https://img.shields.io/badge/cost-%240-brightgreen?style=flat-square" alt="Cost: $0 — no licensing fees">
   </p>
 </p>
 


### PR DESCRIPTION
## Summary

Fixes #83 — improves alt text on all README images for accessibility and SEO.

**Changes:**
- `alt="CI"` → `alt="CI build status for main branch"` (describes which workflow and branch)
- `alt="Alpha"` → `alt="Release status: Alpha"` (clarifies this is a release status indicator)
- `alt="License"` → `alt="License: Apache 2.0"` (includes the license name)
- `alt="Nightly DAST"` → `alt="Nightly DAST workflow status"` (clarifies it's a status badge)
- `alt="Cost: $0"` → `alt="Cost: $0 — no licensing fees"` (adds context for the value)

The architecture diagram (`docs/arch.png`) already had descriptive alt text and was left unchanged.

## Acceptance criteria met

- ✅ Every image in README has meaningful alt text
- ✅ No empty alt attributes on non-decorative images
- ✅ All alts describe what the badge/image conveys, not just the label

## Test plan

- [ ] View README.md on GitHub and confirm badge alt text is human-readable
- [ ] Use a screen reader or browser DevTools accessibility panel to verify alt attributes